### PR TITLE
Remove constructor restriction

### DIFF
--- a/src/Susanoo.Core.Tests/Static/SingleResult/KeyValuePairDeserializer.cs
+++ b/src/Susanoo.Core.Tests/Static/SingleResult/KeyValuePairDeserializer.cs
@@ -1,0 +1,68 @@
+﻿#region
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Runtime.Remoting.Messaging;
+using NUnit.Framework;
+using Susanoo.Pipeline.Command;
+using Susanoo.Pipeline.Command.ResultSets.Processing;
+
+#endregion
+
+namespace Susanoo.Tests.Static.SingleResult
+{
+    [Category("Type Resolution")]
+    [TestFixture]
+    public class KeyValuePairTests
+    {
+        private readonly DatabaseManager _databaseManager = Setup.DatabaseManager;
+
+        [Test(Description = "Tests that results correctly map data to CLR types.")]
+        public void KeyValuePairMap()
+        {
+            var results = CommandManager.DefineCommand("SELECT  Int, String FROM #DataTypeTable;", CommandType.Text)
+                .DefineResults<KeyValuePair<int, string>>()
+                .ForResults(expression =>
+                {
+                    expression.ForProperty(pair => pair.Key, configuration => configuration.UseAlias("Int"));
+                    expression.ForProperty(pair => pair.Value, configuration => configuration.UseAlias("String"));
+                })
+                .Realize()
+                .Execute(_databaseManager);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Count(), 1);
+
+            var first = results.First();
+
+            Assert.AreEqual(first.Key, 1);
+            Assert.AreEqual(first.Value, "varchar");
+        }
+
+        [Test(Description = "Tests that results correctly map data to CLR types.")]
+        public void KeyValuePairMapReverse()
+        {
+            var results = CommandManager.DefineCommand("SELECT  String, Int FROM #DataTypeTable;", CommandType.Text)
+                .DefineResults<KeyValuePair<int, string>>()
+                .ForResults(expression =>
+                {
+                    expression.ForProperty(pair => pair.Key, configuration => configuration.UseAlias("Int"));
+                    expression.ForProperty(pair => pair.Value, configuration => configuration.UseAlias("String"));
+                })
+                .Realize()
+                .Execute(_databaseManager);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Count(), 1);
+
+            var first = results.First();
+
+            Assert.AreEqual(first.Key, 1);
+            Assert.AreEqual(first.Value, "varchar");
+        }
+    }
+}

--- a/src/Susanoo.Core.Tests/Susanoo.Core.Tests.csproj
+++ b/src/Susanoo.Core.Tests/Susanoo.Core.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Dynamic\DynamicTypeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Static\MultipleResults\IdenticalResults.cs" />
+    <Compile Include="Static\SingleResult\KeyValuePairDeserializer.cs" />
     <Compile Include="Static\SingleResult\StaticTypeTest.cs" />
     <Compile Include="Static\TypeTestModel.cs" />
   </ItemGroup>

--- a/src/Susanoo.Core/ISusanooBootstrapper.cs
+++ b/src/Susanoo.Core/ISusanooBootstrapper.cs
@@ -6,6 +6,9 @@ using Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization;
 
 namespace Susanoo
 {
+    /// <summary>
+    /// Exposure points for extending or overriding Susanoo's behavior.
+    /// </summary>
     public interface ISusanooBootstrapper
     {
         /// <summary>

--- a/src/Susanoo.Core/Map.cs
+++ b/src/Susanoo.Core/Map.cs
@@ -2,6 +2,11 @@
 
 namespace Susanoo
 {
+    /// <summary>
+    /// A simple bidirectional Dictionary that allows efficient lookup on either key or value.
+    /// </summary>
+    /// <typeparam name="T1">The type of the t1.</typeparam>
+    /// <typeparam name="T2">The type of the t2.</typeparam>
     internal class Map<T1, T2>
     {
         private readonly IDictionary<T1, T2> _forward;

--- a/src/Susanoo.Core/Pipeline/Command/CommandExpression.cs
+++ b/src/Susanoo.Core/Pipeline/Command/CommandExpression.cs
@@ -326,7 +326,7 @@ namespace Susanoo.Pipeline.Command
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <returns>ICommandResultExpression&lt;TFilter, TResult&gt;.</returns>
-        public ICommandResultExpression<TFilter, TResult> DefineResults<TResult>() where TResult : new()
+        public ICommandResultExpression<TFilter, TResult> DefineResults<TResult>()
         {
             return new CommandResultExpression<TFilter, TResult>(this);
         }
@@ -338,8 +338,6 @@ namespace Susanoo.Pipeline.Command
         /// <typeparam name="TResult2">The type of the result2.</typeparam>
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2> DefineResults<TResult1, TResult2>()
-            where TResult1 : new()
-            where TResult2 : new()
         {
             return new CommandResultExpression<TFilter, TResult1, TResult2>(this);
         }
@@ -353,9 +351,6 @@ namespace Susanoo.Pipeline.Command
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3> DefineResults
             <TResult1, TResult2, TResult3>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
         {
             return new CommandResultExpression<TFilter, TResult1, TResult2, TResult3>(this);
         }
@@ -370,10 +365,6 @@ namespace Susanoo.Pipeline.Command
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4> DefineResults
             <TResult1, TResult2, TResult3, TResult4>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new()
         {
             return new CommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4>(this);
         }
@@ -389,11 +380,6 @@ namespace Susanoo.Pipeline.Command
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4, TResult5&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5> DefineResults
             <TResult1, TResult2, TResult3, TResult4, TResult5>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new()
-            where TResult5 : new()
         {
             return new CommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5>(this);
         }
@@ -410,12 +396,6 @@ namespace Susanoo.Pipeline.Command
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>
             DefineResults<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new()
-            where TResult5 : new()
-            where TResult6 : new()
         {
             return new CommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>(this);
         }
@@ -434,13 +414,6 @@ namespace Susanoo.Pipeline.Command
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>
             DefineResults
             <TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new()
-            where TResult5 : new()
-            where TResult6 : new()
-            where TResult7 : new()
         {
             return
                 new CommandResultExpression

--- a/src/Susanoo.Core/Pipeline/Command/ICommandExpression.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ICommandExpression.cs
@@ -120,8 +120,7 @@ namespace Susanoo.Pipeline.Command
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <returns>IResultMappingExpression&lt;TResult&gt;.</returns>
-        ICommandResultExpression<TFilter, TResult> DefineResults<TResult>()
-            where TResult : new();
+        ICommandResultExpression<TFilter, TResult> DefineResults<TResult>();
 
         /// <summary>
         /// Defines the result mappings (Moves to next Step in Fluent API).
@@ -129,9 +128,7 @@ namespace Susanoo.Pipeline.Command
         /// <typeparam name="TResult1">The type of the result1.</typeparam>
         /// <typeparam name="TResult2">The type of the result2.</typeparam>
         /// <returns>IResultMappingExpression&lt;TResult&gt;.</returns>
-        ICommandResultExpression<TFilter, TResult1, TResult2> DefineResults<TResult1, TResult2>()
-            where TResult1 : new()
-            where TResult2 : new();
+        ICommandResultExpression<TFilter, TResult1, TResult2> DefineResults<TResult1, TResult2>();
 
         /// <summary>
         /// Defines the result mappings (Moves to next Step in Fluent API).
@@ -140,10 +137,7 @@ namespace Susanoo.Pipeline.Command
         /// <typeparam name="TResult2">The type of the result2.</typeparam>
         /// <typeparam name="TResult3">The type of the result3.</typeparam>
         /// <returns>IResultMappingExpression&lt;TResult&gt;.</returns>
-        ICommandResultExpression<TFilter, TResult1, TResult2, TResult3> DefineResults<TResult1, TResult2, TResult3>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new();
+        ICommandResultExpression<TFilter, TResult1, TResult2, TResult3> DefineResults<TResult1, TResult2, TResult3>();
 
         /// <summary>
         /// Defines the result mappings (Moves to next Step in Fluent API).
@@ -154,11 +148,7 @@ namespace Susanoo.Pipeline.Command
         /// <typeparam name="TResult4">The type of the result4.</typeparam>
         /// <returns>IResultMappingExpression&lt;TResult&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4> DefineResults
-            <TResult1, TResult2, TResult3, TResult4>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new();
+            <TResult1, TResult2, TResult3, TResult4>();
 
         /// <summary>
         /// Defines the result mappings (Moves to next Step in Fluent API).
@@ -170,12 +160,7 @@ namespace Susanoo.Pipeline.Command
         /// <typeparam name="TResult5">The type of the result5.</typeparam>
         /// <returns>IResultMappingExpression&lt;TResult&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5> DefineResults
-            <TResult1, TResult2, TResult3, TResult4, TResult5>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new()
-            where TResult5 : new();
+            <TResult1, TResult2, TResult3, TResult4, TResult5>();
 
         /// <summary>
         /// Defines the result mappings (Moves to next Step in Fluent API).
@@ -188,13 +173,7 @@ namespace Susanoo.Pipeline.Command
         /// <typeparam name="TResult6">The type of the result6.</typeparam>
         /// <returns>IResultMappingExpression&lt;TResult&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6> DefineResults
-            <TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new()
-            where TResult5 : new()
-            where TResult6 : new();
+            <TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>();
 
         /// <summary>
         /// Defines the result mappings (Moves to next Step in Fluent API).
@@ -208,14 +187,7 @@ namespace Susanoo.Pipeline.Command
         /// <typeparam name="TResult7">The type of the result7.</typeparam>
         /// <returns>IResultMappingExpression&lt;TResult&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>
-            DefineResults<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>()
-            where TResult1 : new()
-            where TResult2 : new()
-            where TResult3 : new()
-            where TResult4 : new()
-            where TResult5 : new()
-            where TResult6 : new()
-            where TResult7 : new();
+            DefineResults<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>();
     }
 
     /// <summary>

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/CommandResultExpression.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/CommandResultExpression.cs
@@ -80,7 +80,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <typeparam name="TSingle">The type of the single.</typeparam>
         /// <returns>ICommandResultExpression&lt;TFilter, TSingle&gt;.</returns>
         public virtual ICommandResultExpression<TFilter, TSingle> ToSingleResult<TSingle>()
-            where TSingle : new()
         {
             return new CommandResultExpression<TFilter, TSingle>(CommandExpression, Implementor);
         }
@@ -93,7 +92,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult">The type of the result.</typeparam>
     public class CommandResultExpression<TFilter, TResult> : CommandResultCommon<TFilter>,
         ICommandResultExpression<TFilter, TResult>
-        where TResult : new()
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandResultExpression{TFilter, TResult}" /> class.
@@ -194,8 +192,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult2">The type of the 2nd result.</typeparam>
     public class CommandResultExpression<TFilter, TResult1, TResult2> : CommandResultCommon<TFilter>,
         ICommandResultExpression<TFilter, TResult1, TResult2>
-        where TResult1 : new()
-        where TResult2 : new()
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandResultExpression{TFilter, TResult1, TResult2}" /> class.
@@ -229,7 +225,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2> ForResultsOfType<TResultType>(
             Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new()
         {
             Implementor.StoreMapping(mappings);
 
@@ -264,9 +259,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult3">The type of the 3rd result.</typeparam>
     public class CommandResultExpression<TFilter, TResult1, TResult2, TResult3> : CommandResultCommon<TFilter>,
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandResultExpression{TFilter, TResult1, TResult2, TResult3}" />
@@ -302,7 +294,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3> ForResultsOfType<TResultType>(
             Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new()
         {
             Implementor.StoreMapping(mappings);
 
@@ -338,10 +329,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult4">The type of the 4th result.</typeparam>
     public class CommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4> : CommandResultCommon<TFilter>,
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
     {
         /// <summary>
         /// Initializes a new instance of the
@@ -378,7 +365,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4&gt;.</returns>
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4> ForResultsOfType<TResultType>(
             Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new()
         {
             Implementor.StoreMapping(mappings);
 
@@ -417,11 +403,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     public class CommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5> :
         CommandResultCommon<TFilter>,
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
     {
         /// <summary>
         /// Initializes a new instance of the
@@ -460,7 +441,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5> ForResultsOfType
             <TResultType>(
             Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new()
         {
             Implementor.StoreMapping(mappings);
 
@@ -503,12 +483,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     public class CommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6> :
         CommandResultCommon<TFilter>,
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
     {
         /// <summary>
         /// Initializes a new instance of the
@@ -548,7 +522,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>
             ForResultsOfType<TResultType>(
             Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new()
         {
             Implementor.StoreMapping(mappings);
 
@@ -595,13 +568,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     public class CommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7> :
         CommandResultCommon<TFilter>,
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
-        where TResult7 : new()
     {
         /// <summary>
         /// Initializes a new instance of the
@@ -643,7 +609,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         public ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>
             ForResultsOfType<TResultType>(
             Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new()
         {
             Implementor.StoreMapping(mappings);
 

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/CommandResultExtensions.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/CommandResultExtensions.cs
@@ -16,7 +16,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <returns>IResultMapper&lt;TResult&gt;.</returns>
         public static IResultMapper<TResult> GetProcessor<TFilter, TResult>(this
             ICommandResultExpressionCore<TFilter> resultExpression)
-            where TResult : new()
         {
             return SingleResultSetCommandProcessor<TFilter, TResult>.BuildOrRegenResultMapper(
                 resultExpression.ToSingleResult<TResult>());

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/CommandResultImplementor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/CommandResultImplementor.cs
@@ -69,7 +69,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <typeparam name="TResult">The type of the t result.</typeparam>
         /// <param name="mapping">The mapping.</param>
         public virtual void StoreMapping<TResult>(Action<IResultMappingExpression<TFilter, TResult>> mapping)
-            where TResult : new()
         {
             if (_mappingContainer.ContainsKey(typeof(TResult)))
             {

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/ICommandResultExpression.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/ICommandResultExpression.cs
@@ -28,8 +28,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// </summary>
         /// <typeparam name="TSingle">The type of the single.</typeparam>
         /// <returns>ICommandResultExpression&lt;TFilter, TResult&gt;.</returns>
-        ICommandResultExpression<TFilter, TSingle> ToSingleResult<TSingle>()
-            where TSingle : new();
+        ICommandResultExpression<TFilter, TSingle> ToSingleResult<TSingle>();
     }
 
     /// <summary>
@@ -50,8 +49,8 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// </summary>
     /// <typeparam name="TFilter">The type of the filter.</typeparam>
     /// <typeparam name="TResult">The type of the result.</typeparam>
-    public interface ICommandResultExpression<TFilter, TResult> : ICommandResultExpressionCore<TFilter>
-        where TResult : new()
+    public interface ICommandResultExpression<TFilter, TResult> 
+        : ICommandResultExpressionCore<TFilter>
     {
         /// <summary>
         /// Allows customization of result set.
@@ -75,9 +74,8 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TFilter">The type of the filter.</typeparam>
     /// <typeparam name="TResult1">The type of the 1st result.</typeparam>
     /// <typeparam name="TResult2">The type of the 2nd result.</typeparam>
-    public interface ICommandResultExpression<TFilter, TResult1, TResult2> : ICommandResultExpressionCore<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
+    public interface ICommandResultExpression<TFilter, TResult1, TResult2> 
+        : ICommandResultExpressionCore<TFilter>
     {
         /// <summary>
         /// Allows customization of a type of result set.
@@ -86,8 +84,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <param name="mappings">The mappings.</param>
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2> ForResultsOfType<TResultType>(
-            Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new();
+            Action<IResultMappingExpression<TFilter, TResultType>> mappings);
 
         /// <summary>
         /// Realizes the pipeline and compiles result mappings.
@@ -104,11 +101,8 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult1">The type of the 1st result.</typeparam>
     /// <typeparam name="TResult2">The type of the 2nd result.</typeparam>
     /// <typeparam name="TResult3">The type of the 3rd result.</typeparam>
-    public interface ICommandResultExpression<TFilter, TResult1, TResult2, TResult3> :
-        ICommandResultExpressionCore<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
+    public interface ICommandResultExpression<TFilter, TResult1, TResult2, TResult3> 
+        : ICommandResultExpressionCore<TFilter>
     {
         /// <summary>
         /// Allows customization of a type of result set.
@@ -117,8 +111,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <param name="mappings">The mappings.</param>
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3> ForResultsOfType<TResultType>(
-            Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new();
+            Action<IResultMappingExpression<TFilter, TResultType>> mappings);
 
         /// <summary>
         /// Realizes the pipeline and compiles result mappings.
@@ -138,10 +131,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult4">The type of the 4th result.</typeparam>
     public interface ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4> :
         ICommandResultExpressionCore<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
     {
         /// <summary>
         /// Allows customization of a type of result set.
@@ -150,8 +139,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <param name="mappings">The mappings.</param>
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4> ForResultsOfType<TResultType>(
-            Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new();
+            Action<IResultMappingExpression<TFilter, TResultType>> mappings);
 
         /// <summary>
         /// Realizes the pipeline and compiles result mappings.
@@ -172,11 +160,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult5">The type of the 5th result.</typeparam>
     public interface ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5> :
         ICommandResultExpressionCore<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
     {
         /// <summary>
         /// Allows customization of a type of result set.
@@ -186,8 +169,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4, TResult5&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5> ForResultsOfType
             <TResultType>(
-            Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new();
+            Action<IResultMappingExpression<TFilter, TResultType>> mappings);
 
         /// <summary>
         /// Realizes the pipeline and compiles result mappings.
@@ -209,12 +191,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult6">The type of the 6th result.</typeparam>
     public interface ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6> :
         ICommandResultExpressionCore<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
     {
         /// <summary>
         /// Allows customization of a type of result set.
@@ -224,8 +200,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6> ForResultsOfType
             <TResultType>(
-            Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new();
+            Action<IResultMappingExpression<TFilter, TResultType>> mappings);
 
         /// <summary>
         /// Realizes the pipeline and compiles result mappings.
@@ -249,13 +224,6 @@ namespace Susanoo.Pipeline.Command.ResultSets
     /// <typeparam name="TResult7">The type of the 7th result.</typeparam>
     public interface ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6,
         TResult7> : ICommandResultExpressionCore<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
-        where TResult7 : new()
     {
         /// <summary>
         /// Allows customization of a type of result set.
@@ -265,8 +233,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// <returns>ICommandResultExpression&lt;TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7&gt;.</returns>
         ICommandResultExpression<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>
             ForResultsOfType<TResultType>(
-            Action<IResultMappingExpression<TFilter, TResultType>> mappings)
-            where TResultType : new();
+            Action<IResultMappingExpression<TFilter, TResultType>> mappings);
 
         /// <summary>
         /// Realizes the pipeline and compiles result mappings.

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/ICommandResultImplementor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/ICommandResultImplementor.cs
@@ -27,8 +27,7 @@ namespace Susanoo.Pipeline.Command.ResultSets
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="mapping">The mapping.</param>
-        void StoreMapping<TResult>(Action<IResultMappingExpression<TFilter, TResult>> mapping)
-            where TResult : new();
+        void StoreMapping<TResult>(Action<IResultMappingExpression<TFilter, TResult>> mapping);
 
         /// <summary>
         /// Exports a results mappings for processing.

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/IResultMappingExpression.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/IResultMappingExpression.cs
@@ -15,7 +15,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Mapping
     /// <typeparam name="TFilter">The type of the filter.</typeparam>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     public interface IResultMappingExpression<TFilter, TResult> : IResultMappingExport, IFluentPipelineFragment
-        where TResult : new()
     {
         /// <summary>
         /// Clears the result mappings.

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/IResultMappingExpression.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/IResultMappingExpression.cs
@@ -40,5 +40,7 @@ namespace Susanoo.Pipeline.Command.ResultSets.Mapping
         /// <returns>IResultMappingExpression&lt;TFilter, TResult&gt;.</returns>
         IResultMappingExpression<TFilter, TResult> ForProperty(string propertyName,
             Action<IPropertyMappingConfiguration> options);
+
+
     }
 }

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/IResultMappingImplementor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/IResultMappingImplementor.cs
@@ -10,7 +10,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Mapping
     /// </summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     public interface IResultMappingImplementor<TResult> : IResultMappingExport, IFluentPipelineFragment
-        where TResult : new()
     {
         /// <summary>
         /// Clears the result mappings.

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/ResultMappingExpression.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/ResultMappingExpression.cs
@@ -18,7 +18,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Mapping
     /// <typeparam name="TResult">The type of the result.</typeparam>
     public class ResultMappingExpression<TFilter, TResult>
         : IResultMappingExpression<TFilter, TResult>
-        where TResult : new()
     {
         private readonly IResultMappingImplementor<TResult> _implementor;
 

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/ResultMappingImplementor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Mapping/ResultMappingImplementor.cs
@@ -18,7 +18,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Mapping
     /// <typeparam name="TResult">The type of the result.</typeparam>
     public class ResultMappingImplementor<TResult>
         : IResultMappingImplementor<TResult>
-        where TResult : new()
     {
         private readonly IDictionary<string, IPropertyMapping> _mappingActions =
             new Dictionary<string, IPropertyMapping>();

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/BuiltInTypeDeserializer.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/BuiltInTypeDeserializer.cs
@@ -10,7 +10,7 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
     public static class BuiltInTypeDeserializer
     {
         /// <summary>
-        /// Dumps all columns into an array for simple use cases.
+        /// Reads the first value only.
         /// </summary>
         /// <param name="reader">The reader.</param>
         /// <param name="checker">The column checker.</param>

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/ComplexTypeDeserializer.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/ComplexTypeDeserializer.cs
@@ -163,7 +163,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
         /// <typeparam name="TResult">The type of the t result.</typeparam>
         /// <returns>Func&lt;IDataReader, ColumnChecker, IEnumerable&lt;TResult&gt;&gt;.</returns>
         public static Func<IDataReader, ColumnChecker, IEnumerable<TResult>> Compile<TResult>(ICommandResultMappingExport mapping, Type resultType)
-            where TResult : new()
         {
             var result = Compile(mapping, resultType);
 

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/DeserializerResolver.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/DeserializerResolver.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 
 namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
@@ -21,12 +23,34 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
 
             if (typeof(TResult) == typeof(DynamicRow) || typeof(TResult) == typeof(object))
                 deserializer = DynamicRowDeserializer.Deserialize<TResult>;
-            else if (CommandManager.GetDbType(typeof(TResult)) != null)
+            else if (CommandManager.GetDbType(typeof (TResult)) != null)
                 deserializer = BuiltInTypeDeserializer.Deserialize<TResult>;
             else
-                deserializer = ComplexTypeDeserializer.Compile<TResult>(mappings, typeof(TResult));
+            {
+                deserializer = ResolveCustomDeserializer<TResult>(mappings) 
+                    ?? ComplexTypeDeserializer.Compile<TResult>(mappings, typeof (TResult));
+            }
 
             return deserializer;
+        }
+
+        /// <summary>
+        /// Resolves any custom deserializers.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the t result.</typeparam>
+        /// <param name="mappings">The mappings.</param>
+        /// <returns>Func&lt;IDataReader, ColumnChecker, IEnumerable&lt;TResult&gt;&gt;.</returns>
+        public virtual Func<IDataReader, ColumnChecker, IEnumerable<TResult>> ResolveCustomDeserializer<TResult>(
+            ICommandResultMappingExport mappings)
+        {
+            Func<IDataReader, ColumnChecker, IEnumerable<TResult>> customDeserializer = null;
+
+            if (typeof (TResult).IsGenericType && typeof (TResult).GetGenericTypeDefinition() == typeof (KeyValuePair<,>))
+            {
+                customDeserializer = new KeyValuePairDeserializer<TResult>(mappings).Deserialize;
+            }
+
+            return customDeserializer;
         }
     }
 }

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/DeserializerResolver.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/DeserializerResolver.cs
@@ -16,7 +16,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
         /// <returns>Func&lt;IDataReader, ColumnChecker, IEnumerable&lt;TResult&gt;&gt;.</returns>
         public virtual Func<IDataReader, ColumnChecker, IEnumerable<TResult>>
             Resolve<TResult>(ICommandResultMappingExport mappings)
-                where TResult : new()
         {
             Func<IDataReader, ColumnChecker, IEnumerable<TResult>> deserializer;
 

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/DynamicRow.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/DynamicRow.cs
@@ -162,9 +162,8 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
         /// <param name="expression">
         /// The expression representing this <see cref="T:System.Dynamic.DynamicMetaObject" /> during the dynamic binding process.
         /// </param>
-        /// <param name="restrictions">
-        /// The set of binding restrictions under which the binding is valid.
-        /// </param>
+        /// <param name="restrictions">The set of binding restrictions under which the binding is valid.</param>
+        /// <param name="columns">The columns.</param>
         public DynamicRowMeta(Expression expression, BindingRestrictions restrictions, ColumnChecker columns)
             : base(expression, restrictions)
         {

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/IDeserializer.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/IDeserializer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Data;
+
+namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
+{
+    /// <summary>
+    /// Provides the ability to map objects with constructors or special considerations.
+    /// </summary>
+    public interface ICustomDeserializer<out TResult>
+    {
+        /// <summary>
+        /// Deserializes into a complex object from a data reader.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="reader">The data reader.</param>
+        /// <param name="checker">The column object.</param>
+        /// <returns>IEnumerable&lt;TResult&gt;.</returns>
+        IEnumerable<TResult> Deserialize(IDataReader reader, ColumnChecker checker);
+    }
+}

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/IDeserializerResolver.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/IDeserializerResolver.cs
@@ -15,7 +15,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
         /// <typeparam name="TResult">The type of the t result.</typeparam>
         /// <returns>Func&lt;IDataReader, ColumnChecker, IEnumerable&lt;TResult&gt;&gt;.</returns>
         Func<IDataReader, ColumnChecker, IEnumerable<TResult>>
-            Resolve<TResult>(ICommandResultMappingExport mappings)
-            where TResult : new();
+            Resolve<TResult>(ICommandResultMappingExport mappings);
     }
 }

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/KeyValuePairDeserializer.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/Deserialization/KeyValuePairDeserializer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using Susanoo.Pipeline.Command.ResultSets.Mapping.Properties;
+
+namespace Susanoo.Pipeline.Command.ResultSets.Processing.Deserialization
+{
+    /// <summary>
+    /// Maps properties to a KeyValuePair using Activator
+    /// </summary>
+    /// <typeparam name="TResult">The type of the t result.</typeparam>
+    public class KeyValuePairDeserializer<TResult> : ICustomDeserializer<TResult>
+    {
+        private readonly IDictionary<string, IPropertyMapping> _props;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyValuePairDeserializer{TResult}"/> class.
+        /// </summary>
+        /// <param name="mappings">The mappings.</param>
+        public KeyValuePairDeserializer(ICommandResultMappingExport mappings)
+        {
+            _props = mappings.Export(typeof(TResult));
+        }
+
+        /// <summary>
+        /// Deserializes into a KeyValuePair from a data reader.
+        /// </summary>
+        /// <param name="reader">The data reader.</param>
+        /// <param name="checker">The column object.</param>
+        /// <returns>IEnumerable&lt;TResult&gt;.</returns>
+        public IEnumerable<TResult> Deserialize(IDataReader reader, ColumnChecker checker)
+        {
+            var keyAlias = "Key";
+            IPropertyMapping keyMapping;
+            var valueAlias = "Value";
+            IPropertyMapping valueMapping;
+
+            if (_props.TryGetValue("Key", out keyMapping))
+                keyAlias = keyMapping.ActiveAlias;
+            if (_props.TryGetValue("Value", out valueMapping))
+                valueAlias = valueMapping.ActiveAlias;
+
+            IList resultSet = new List<TResult>();
+
+            checker = checker ?? new ColumnChecker();
+
+            while (reader.Read())
+            {
+                resultSet.Add(Activator.CreateInstance(typeof (TResult), 
+                    reader.GetValue(checker.HasColumn(reader, keyAlias)),
+                    reader.GetValue(checker.HasColumn(reader, valueAlias))));
+
+            }
+
+            return (IEnumerable<TResult>)resultSet;
+        }
+    }
+}

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/ICommandProcessor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/ICommandProcessor.cs
@@ -106,7 +106,7 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
             TFilter filter, CancellationToken cancellationToken, params DbParameter[] explicitParameters);
     }
 
-    public interface ICommandProcessorAsync<in TFilter, TResult> where TResult : new()
+    public interface ICommandProcessorAsync<in TFilter, TResult>
     {
         /// <summary>
         /// Assembles a data command for an ADO.NET provider,
@@ -169,7 +169,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
 #if !NETFX40
             , ICommandProcessorAsync<TFilter, TResult>
 #endif
-        where TResult : new()
     {
         /// <summary>
         /// Gets the command result expression.
@@ -230,8 +229,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     /// <remarks>Appropriate mapping expressions are compiled at the point this interface becomes available.</remarks>
     public interface ICommandProcessor<TFilter, TResult1, TResult2>
         : ICommandProcessorWithResults, ICommandProcessorInterop<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
     {
         /// <summary>
         /// Enables result caching.
@@ -283,9 +280,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     /// <remarks>Appropriate mapping expressions are compiled at the point this interface becomes available.</remarks>
     public interface ICommandProcessor<TFilter, TResult1, TResult2, TResult3>
         : ICommandProcessorWithResults, ICommandProcessorInterop<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
     {
         /// <summary>
         /// Enables result caching.
@@ -340,10 +334,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     /// <remarks>Appropriate mapping expressions are compiled at the point this interface becomes available.</remarks>
     public interface ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4>
         : ICommandProcessorWithResults, ICommandProcessorInterop<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
     {
         /// <summary>
         /// Enables result caching.
@@ -401,11 +391,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     /// <remarks>Appropriate mapping expressions are compiled at the point this interface becomes available.</remarks>
     public interface ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5>
         : ICommandProcessorWithResults, ICommandProcessorInterop<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
     {
         /// <summary>
         /// Enables result caching.
@@ -470,12 +455,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     /// <remarks>Appropriate mapping expressions are compiled at the point this interface becomes available.</remarks>
     public interface ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>
         : ICommandProcessorWithResults, ICommandProcessorInterop<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
     {
         /// <summary>
         /// Enables result caching.
@@ -543,13 +522,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     /// <remarks>Appropriate mapping expressions are compiled at the point this interface becomes available.</remarks>
     public interface ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>
         : ICommandProcessorWithResults, ICommandProcessorInterop<TFilter>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
-        where TResult7 : new()
     {
         /// <summary>
         /// Enables result caching.

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/MultipleResultSetCommandProcessor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/MultipleResultSetCommandProcessor.cs
@@ -17,8 +17,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     public class MultipleResultSetCommandProcessor<TFilter, TResult1, TResult2>
         : CommandProcessorWithResults<TFilter>,
             ICommandProcessor<TFilter, TResult1, TResult2>
-        where TResult1 : new()
-        where TResult2 : new()
     {
         private const int ResultCount = 2;
         private readonly ICommandExpression<TFilter> _commandExpression;
@@ -196,9 +194,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     public class MultipleResultSetCommandProcessor<TFilter, TResult1, TResult2, TResult3>
         : CommandProcessorWithResults<TFilter>,
             ICommandProcessor<TFilter, TResult1, TResult2, TResult3>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
     {
         private const int ResultCount = 3;
         private readonly ICommandExpression<TFilter> _commandExpression;
@@ -385,10 +380,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     public class MultipleResultSetCommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4>
         : CommandProcessorWithResults<TFilter>,
             ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
     {
         private const int ResultCount = 4;
         private readonly ICommandExpression<TFilter> _commandExpression;
@@ -584,11 +575,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     public class MultipleResultSetCommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5>
         : CommandProcessorWithResults<TFilter>,
             ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
     {
         private const int ResultCount = 5;
         private readonly ICommandExpression<TFilter> _commandExpression;
@@ -793,12 +779,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     public class MultipleResultSetCommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>
         : CommandProcessorWithResults<TFilter>,
             ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
     {
         private const int ResultCount = 6;
         private readonly ICommandExpression<TFilter> _commandExpression;
@@ -1013,13 +993,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
         TResult7>
         : CommandProcessorWithResults<TFilter>,
             ICommandProcessor<TFilter, TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7>
-        where TResult1 : new()
-        where TResult2 : new()
-        where TResult3 : new()
-        where TResult4 : new()
-        where TResult5 : new()
-        where TResult6 : new()
-        where TResult7 : new()
     {
         private const int ResultCount = 7;
         private readonly ICommandExpression<TFilter> _commandExpression;

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/SingleResultSetCommandProcessor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/SingleResultSetCommandProcessor.cs
@@ -198,7 +198,9 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
                     {
                         results = (((IResultMapper<TResult>)this).MapResult(records, ColumnReport, CompiledMapping));
 
-                        ColumnReport = ((ListResult<TResult>)results).ColumnReport;
+                        var result = results as ListResult<TResult>;
+                        if(result != null)
+                            ColumnReport = result.ColumnReport;
                     }
                 }
                 catch (Exception ex)

--- a/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/SingleResultSetCommandProcessor.cs
+++ b/src/Susanoo.Core/Pipeline/Command/ResultSets/Processing/SingleResultSetCommandProcessor.cs
@@ -18,7 +18,6 @@ namespace Susanoo.Pipeline.Command.ResultSets.Processing
     /// <remarks>Appropriate mapping expressions are compiled at the point this interface becomes available.</remarks>
     public sealed class SingleResultSetCommandProcessor<TFilter, TResult>
         : CommandProcessorWithResults<TFilter>, ICommandProcessor<TFilter, TResult>, IResultMapper<TResult>
-        where TResult : new()
     {
         private ColumnChecker _columnChecker;
 

--- a/src/Susanoo.Core/Susanoo.Core.csproj
+++ b/src/Susanoo.Core/Susanoo.Core.csproj
@@ -115,10 +115,12 @@
     <Compile Include="Pipeline\Command\ResultSets\Mapping\DefaultResultMapping.cs" />
     <Compile Include="Pipeline\Command\ResultSets\Processing\Deserialization\DeserializerResolver.cs" />
     <Compile Include="Pipeline\Command\ResultSets\Processing\Deserialization\DynamicRowDeserializer.cs" />
+    <Compile Include="Pipeline\Command\ResultSets\Processing\Deserialization\IDeserializer.cs" />
     <Compile Include="Pipeline\Command\ResultSets\Processing\Deserialization\IDeserializerResolver.cs" />
     <Compile Include="Murmur3.cs" />
     <Compile Include="Pipeline\Command\ResultSets\ICommandResultExpression.cs" />
     <Compile Include="Pipeline\Command\ResultSets\ICommandResultImplementor.cs" />
+    <Compile Include="Pipeline\Command\ResultSets\Processing\Deserialization\KeyValuePairDeserializer.cs" />
     <Compile Include="Pipeline\IFluentPipelineFragment.cs" />
     <Compile Include="Pipeline\Command\ResultSets\Processing\IResultMapper.cs" />
     <Compile Include="Pipeline\Command\ResultSets\Processing\ListResult.cs" />


### PR DESCRIPTION
Adds KeyValuePair deserialization and removes new() generic restriction. Standard method of introducing additional deserializers as well.